### PR TITLE
Add hostname to pushgateway metrics

### DIFF
--- a/dubbo-metrics/dubbo-metrics-prometheus/src/main/java/org/apache/dubbo/metrics/prometheus/PrometheusMetricsReporter.java
+++ b/dubbo-metrics/dubbo-metrics-prometheus/src/main/java/org/apache/dubbo/metrics/prometheus/PrometheusMetricsReporter.java
@@ -63,9 +63,16 @@ public class PrometheusMetricsReporter extends AbstractMetricsReporter {
     private ScheduledExecutorService pushJobExecutor = null;
     private HttpServer prometheusExporterHttpServer = null;
     private Thread httpServerThread = null;
-
+    private static String HOSTNAME = "";
+    
     public PrometheusMetricsReporter(URL url, ApplicationModel applicationModel) {
         super(url, applicationModel);
+        try {
+			HOSTNAME = InetAddress.getLocalHost().getHostName();
+			logger.info("get host name:" + HOSTNAME);
+		} catch (UnknownHostException e) {
+			logger.error("", e);
+		}
     }
 
     @Override
@@ -124,9 +131,11 @@ public class PrometheusMetricsReporter extends AbstractMetricsReporter {
     }
 
     protected void push(PushGateway pushGateway, String job) {
+        Map<String, String> groupingKey = new HashMap<String, String>();
+		groupingKey.put("instance", HOSTNAME);
         try {
             refreshData();
-            pushGateway.pushAdd(prometheusRegistry.getPrometheusRegistry(), job);
+            pushGateway.pushAdd(prometheusRegistry.getPrometheusRegistry(), job, groupingKey);
         } catch (IOException e) {
             logger.error(COMMON_METRICS_COLLECTOR_EXCEPTION, "", "", "Error occurred when pushing metrics to prometheus: ", e);
         }


### PR DESCRIPTION
add hostname to prometheus metrics

## What is the purpose of the change
Pushgateway 会增加instance为hostname的指标，后续看板可以根据服务器名称进行选择，当前默认是使用服务器IP不能直观展示服务器名称


## Brief changelog


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
